### PR TITLE
enhancement: Extend supported quotas

### DIFF
--- a/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
+++ b/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
@@ -124,6 +124,27 @@
     }
   },
   "s3": {
+    "L-146D5F0C": {
+      "parameters": {
+        "expression": "SELECT supplementaryConfiguration WHERE resourceType = 'AWS::S3::Bucket'",
+        "jmespath": "max([].supplementaryConfiguration.BucketLifecycleConfiguration.length(rules))"
+      },
+      "type": "config"
+    },
+    "L-3E24E5F9": {
+      "parameters": {
+        "expression": "SELECT supplementaryConfiguration WHERE resourceType = 'AWS::S3::Bucket'",
+        "jmespath": "max([].supplementaryConfiguration.BucketNotificationConfiguration.length(configurations))"
+      },
+      "type": "config"
+    },
+    "L-55BA2C6C": {
+      "parameters": {
+        "expression": "SELECT tags WHERE resourceType = 'AWS::S3::Bucket'",
+        "jmespath": "max([].length(tags))"
+      },
+      "type": "config"
+    },
     "L-DC2B2D3D": {
       "parameters": {
         "expression": "SELECT resourceId WHERE resourceType = 'AWS::S3::Bucket'",

--- a/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
+++ b/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
@@ -123,6 +123,71 @@
       "type": "config"
     }
   },
+  "redshift": {
+    "L-2E428669": {
+      "parameters": {
+        "expression": "SELECT resourceId WHERE resourceType = 'AWS::Redshift::ClusterSnapshot' AND configuration.snapshotType = 'manual'",
+        "jmespath": "length([])"
+      },
+      "type": "config"
+    },
+    "L-6C6B6042": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::ClusterSubnetGroup'",
+        "jmespath": "max([].configuration.length(subnets))"
+      },
+      "type": "config"
+    },
+    "L-7C6A532D": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::Cluster'",
+        "jmespath": "max([].configuration.length(iamRoles))"
+      },
+      "type": "config"
+    },
+    "L-84537943": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::Cluster'",
+        "jmespath": "[?starts_with(@.configuration.nodeType, 'dc2.')] | max([].configuration.numberOfNodes)"
+      },
+      "type": "config"
+    },
+    "L-93AC8AE6": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::Cluster'",
+        "jmespath": "[?starts_with(@.configuration.nodeType, 'ra3.')] | max([].configuration.numberOfNodes)"
+      },
+      "type": "config"
+    },
+    "L-A3830BB3": {
+      "parameters": {
+        "expression": "SELECT resourceId WHERE resourceType = 'AWS::Redshift::ClusterParameterGroup'",
+        "jmespath": "length([])"
+      },
+      "type": "config"
+    },
+    "L-BE12F428": {
+      "parameters": {
+        "expression": "SELECT resourceId WHERE resourceType = 'AWS::Redshift::ClusterSubnetGroup'",
+        "jmespath": "length([])"
+      },
+      "type": "config"
+    },
+    "L-C7372F73": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::Cluster'",
+        "jmespath": "[?starts_with(@.configuration.nodeType, 'ds2.')] | max([].configuration.numberOfNodes)"
+      },
+      "type": "config"
+    },
+    "L-F9D462EE": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::Redshift::Cluster'",
+        "jmespath": "sum([].configuration.numberOfNodes)"
+      },
+      "type": "config"
+    }
+  },
   "s3": {
     "L-146D5F0C": {
       "parameters": {

--- a/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
+++ b/service_quotas_manager/service_quotas_manager/custom_collection_queries.json
@@ -133,6 +133,27 @@
     }
   },
   "vpc": {
+    "L-1B52E74A": {
+      "parameters": {
+        "expression": "SELECT resourceId WHERE resourceType = 'AWS::EC2::VPCEndpoint' AND configuration.vpcEndpointType = 'Gateway'",
+        "jmespath": "length([])"
+      },
+      "type": "config"
+    },
+    "L-29B6F2EB": {
+      "parameters": {
+        "expression": "SELECT configuration.vpcId, COUNT(*) WHERE resourceType = 'AWS::EC2::VPCEndpoint' AND configuration.vpcEndpointType = 'Interface' GROUP BY configuration.vpcId ORDER BY COUNT(*) DESC",
+        "jmespath": "max([].\"COUNT(*)\")"
+      },
+      "type": "config"
+    },
+    "L-2AFB9258": {
+      "parameters": {
+        "expression": "SELECT relationships WHERE resourceType = 'AWS::EC2::NetworkInterface'",
+        "jmespath": "max([].length(relationships[?resourceType == 'AWS::EC2::SecurityGroup']))"
+      },
+      "type": "config"
+    },
     "L-407747CB": {
       "parameters": {
         "expression": "SELECT configuration.vpcId, COUNT(*) WHERE resourceType = 'AWS::EC2::Subnet' GROUP BY configuration.vpcId ORDER BY COUNT(*) DESC",
@@ -140,10 +161,38 @@
       },
       "type": "config"
     },
+    "L-45FE3B85": {
+      "parameters": {
+        "expression": "SELECT resourceId WHERE resourceType = 'AWS::EC2::EgressOnlyInternetGateway'",
+        "jmespath": "length([])"
+      },
+      "type": "config"
+    },
     "L-589F43AA": {
       "parameters": {
         "expression": "SELECT configuration.vpcId, COUNT(*) WHERE resourceType = 'AWS::EC2::RouteTable' GROUP BY configuration.vpcId ORDER BY COUNT(*) DESC",
         "jmespath": "max([].\"COUNT(*)\")"
+      },
+      "type": "config"
+    },
+    "L-5F53652F": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::EC2::NatGateway'",
+        "jmespath": "max([].configuration.length(natGatewayAddresses[?starts_with(@.associationId, 'eipassoc')]))"
+      },
+      "type": "config"
+    },
+    "L-83CA0A9D": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::EC2::VPC'",
+        "jmespath": "max([].configuration.length(cidrBlockAssociationSet[?cidrBlockState.state == 'associated']))"
+      },
+      "type": "config"
+    },
+    "L-93826ACB": {
+      "parameters": {
+        "expression": "SELECT configuration WHERE resourceType = 'AWS::EC2::RouteTable'",
+        "jmespath": "max([].configuration.length(routes))"
       },
       "type": "config"
     },

--- a/service_quotas_manager/tests/conftest.py
+++ b/service_quotas_manager/tests/conftest.py
@@ -46,6 +46,14 @@ def cost_explorer():
     return botocore.session.get_session().create_client("ce")
 
 
+### AWS Config Expression Results
+
+
+@pytest.fixture
+def aws_config_expression_results():
+    return json.load(open(Path(FIXTURES_PATH) / "custom_collection_queries.json"))
+
+
 ### AWS Service Responses
 
 

--- a/service_quotas_manager/tests/fixtures/custom_collection_queries.json
+++ b/service_quotas_manager/tests/fixtures/custom_collection_queries.json
@@ -1,0 +1,406 @@
+{
+  "acm": {
+    "L-D2CB7DE9": [
+      {
+        "resourceId": "cert-001"
+      },
+      {
+        "resourceId": "cert-002"
+      }
+    ],
+    "L-F141DD1D": [
+      {
+        "resourceId": "cert-001"
+      },
+      {
+        "resourceId": "cert-002"
+      }
+    ],
+    "L-FB94F0B0": [
+      {
+        "subjectAlternativeNames": [
+          "alt-name-1",
+          "alt-name-2"
+        ]
+      },
+      {
+        "subjectAlternativeNames": [
+          "alt-name-1"
+        ]
+      }
+    ]
+  },
+  "apigateway": {
+    "L-379E48B0": [
+      {
+        "relationships": [
+          {
+            "resourceType": "AWS::ApiGateway::Stage"
+          }
+        ]
+      },
+      {
+        "relationships": [
+          {
+            "resourceType": "AWS::ApiGateway::Stage"
+          },
+          {
+            "resourceType": "AWS::ApiGateway::Stage"
+          }
+        ]
+      }
+    ],
+    "L-A966AB5C": [
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "PRIVATE"
+            ]
+          }
+        }
+      },
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "PRIVATE"
+            ]
+          }
+        }
+      }
+    ],
+    "L-AA0FF27B": [
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "REGIONAL"
+            ]
+          }
+        }
+      },
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "REGIONAL"
+            ]
+          }
+        }
+      }
+    ],
+    "L-B97207D0": [
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "EDGE"
+            ]
+          }
+        }
+      },
+      {
+        "configuration": {
+          "endpointConfiguration": {
+            "types": [
+              "EDGE"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "dynamodb": {
+    "L-F7858A77": [
+      {
+        "configuration": {
+          "globalSecondaryIndexes": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "globalSecondaryIndexes": [
+            "a"
+          ]
+        }
+      }
+    ],
+    "L-F98FE922": [
+      {
+        "resourceId": "tbl-001"
+      },
+      {
+        "resourceId": "tbl-002"
+      }
+    ]
+  },
+  "ec2": {
+    "L-0263D0A3": [
+      {
+        "resourceId": "eip-001"
+      },
+      {
+        "resourceId": "eip-002"
+      }
+    ],
+    "L-FB451C26": [
+      {
+        "resourceId": "lt-001"
+      },
+      {
+        "resourceId": "lt-002"
+      }
+    ]
+  },
+  "lambda": {
+    "L-01237738": [
+      {
+        "configuration": {
+          "layers": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "layers": [
+            "a"
+          ]
+        }
+      }
+    ],
+    "L-9FEE3D26": [
+      {
+        "resourceId": "eni-001"
+      },
+      {
+        "resourceId": "eni-002"
+      }
+    ]
+  },
+  "rds": {
+    "L-272F1212": [
+      {
+        "resourceId": "snap-001"
+      },
+      {
+        "resourceId": "snap-002"
+      }
+    ],
+    "L-7B6409FD": [
+      {
+        "resourceId": "db-001"
+      },
+      {
+        "resourceId": "db-002"
+      }
+    ],
+    "L-9B510759": [
+      {
+        "resourceId": "snap-001"
+      },
+      {
+        "resourceId": "snap-002"
+      }
+    ]
+  },
+  "s3": {
+    "L-DC2B2D3D": [
+      {
+        "resourceId": "bucket-001"
+      },
+      {
+        "resourceId": "bucket-002"
+      }
+    ]
+  },
+  "vpc": {
+    "L-1B52E74A": [
+      {
+        "resourceId": "ep-001"
+      },
+      {
+        "resourceId": "ep-002"
+      }
+    ],
+    "L-29B6F2EB": [
+      {
+        "COUNT(*)": 1,
+        "vpcId": "vpc-001"
+      },
+      {
+        "COUNT(*)": 2,
+        "vpcId": "vpc-002"
+      }
+    ],
+    "L-2AFB9258": [
+      {
+        "relationships": [
+          {
+            "resourceType": "AWS::EC2::SecurityGroup"
+          },
+          {
+            "resourceType": "AWS::EC2::SecurityGroup"
+          },
+          {
+            "resourceType": "AWS::EC2::Subnet"
+          }
+        ]
+      },
+      {
+        "relationships": [
+          {
+            "resourceType": "AWS::EC2::VPC"
+          },
+          {
+            "resourceType": "AWS::EC2::Subnet"
+          }
+        ]
+      }
+    ],
+    "L-407747CB": [
+      {
+        "COUNT(*)": 1,
+        "vpcId": "vpc-001"
+      },
+      {
+        "COUNT(*)": 2,
+        "vpcId": "vpc-002"
+      }
+    ],
+    "L-45FE3B85": [
+      {
+        "resourceId": "gw-001"
+      },
+      {
+        "resourceId": "gw-002"
+      }
+    ],
+    "L-589F43AA": [
+      {
+        "COUNT(*)": 1,
+        "vpcId": "vpc-001"
+      },
+      {
+        "COUNT(*)": 2,
+        "vpcId": "vpc-002"
+      }
+    ],
+    "L-5F53652F": [
+      {
+        "configuration": {
+          "natGatewayAddresses": [
+            {
+              "associationId": "eipassoc-001"
+            },
+            {
+              "associationId": "eipassoc-002"
+            }
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "natGatewayAddresses": [
+            {
+              "associationId": "eipassoc-001"
+            }
+          ]
+        }
+      }
+    ],
+    "L-83CA0A9D": [
+      {
+        "configuration": {
+          "cidrBlockAssociationSet": [
+            {
+              "cidrBlockState": {
+                "state": "associated"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "cidrBlockAssociationSet": [
+            {
+              "cidrBlockState": {
+                "state": "associated"
+              }
+            },
+            {
+              "cidrBlockState": {
+                "state": "associated"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "L-93826ACB": [
+      {
+        "configuration": {
+          "routes": [
+            {},
+            {}
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "routes": [
+            {}
+          ]
+        }
+      }
+    ],
+    "L-A4707A72": [
+      {
+        "resourceId": "igw-001"
+      },
+      {
+        "resourceId": "igw-002"
+      }
+    ],
+    "L-B4A6D682": [
+      {
+        "COUNT(*)": 1,
+        "vpcId": "vpc-001"
+      },
+      {
+        "COUNT(*)": 2,
+        "vpcId": "vpc-002"
+      }
+    ],
+    "L-DF5E4CA3": [
+      {
+        "resourceId": "eni-001"
+      },
+      {
+        "resourceId": "eni-002"
+      }
+    ],
+    "L-E79EC296": [
+      {
+        "resourceId": "sg-001"
+      },
+      {
+        "resourceId": "sg-002"
+      }
+    ],
+    "L-F678F1CE": [
+      {
+        "resourceId": "vpc-001"
+      },
+      {
+        "resourceId": "vpc-002"
+      }
+    ]
+  }
+}

--- a/service_quotas_manager/tests/fixtures/custom_collection_queries.json
+++ b/service_quotas_manager/tests/fixtures/custom_collection_queries.json
@@ -209,6 +209,122 @@
       }
     ]
   },
+  "redshift": {
+    "L-2E428669": [
+      {
+        "resourceId": "snap-001"
+      },
+      {
+        "resourceId": "snap-002"
+      }
+    ],
+    "L-6C6B6042": [
+      {
+        "configuration": {
+          "subnets": [
+            {},
+            {}
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "subnets": [
+            {}
+          ]
+        }
+      }
+    ],
+    "L-7C6A532D": [
+      {
+        "configuration": {
+          "iamRoles": [
+            {},
+            {}
+          ]
+        }
+      },
+      {
+        "configuration": {
+          "iamRoles": [
+            {}
+          ]
+        }
+      }
+    ],
+    "L-84537943": [
+      {
+        "configuration": {
+          "nodeType": "dc2.small",
+          "numberOfNodes": 2
+        }
+      },
+      {
+        "configuration": {
+          "nodeType": "dc2.large",
+          "numberOfNodes": 1
+        }
+      }
+    ],
+    "L-93AC8AE6": [
+      {
+        "configuration": {
+          "nodeType": "ra3.small",
+          "numberOfNodes": 2
+        }
+      },
+      {
+        "configuration": {
+          "nodeType": "ra3.large",
+          "numberOfNodes": 1
+        }
+      }
+    ],
+    "L-A3830BB3": [
+      {
+        "resourceId": "cluster-1"
+      },
+      {
+        "resourceId": "cluster-2"
+      }
+    ],
+    "L-BE12F428": [
+      {
+        "resourceId": "group-001"
+      },
+      {
+        "resourceId": "group-002"
+      }
+    ],
+    "L-C7372F73": [
+      {
+        "configuration": {
+          "nodeType": "ds2.small",
+          "numberOfNodes": 2
+        }
+      },
+      {
+        "configuration": {
+          "nodeType": "ds2.large",
+          "numberOfNodes": 1
+        }
+      }
+    ],
+    "L-F9D462EE": [
+      {
+        "configuration": {
+          "nodeType": "ds2.small",
+          "numberOfNodes": 1
+        }
+      },
+      {
+        "configuration": {
+          "nodeType": "ds2.large",
+          "numberOfNodes": 1
+        }
+      }
+    ]
+  },
   "s3": {
     "L-146D5F0C": [
       {

--- a/service_quotas_manager/tests/fixtures/custom_collection_queries.json
+++ b/service_quotas_manager/tests/fixtures/custom_collection_queries.json
@@ -210,6 +210,61 @@
     ]
   },
   "s3": {
+    "L-146D5F0C": [
+      {
+        "supplementaryConfiguration": {
+          "BucketLifecycleConfiguration": {
+            "rules": [
+              "a",
+              "b"
+            ]
+          }
+        }
+      },
+      {
+        "supplementaryConfiguration": {
+          "BucketLifecycleConfiguration": {
+            "rules": [
+              "a"
+            ]
+          }
+        }
+      }
+    ],
+    "L-3E24E5F9": [
+      {
+        "supplementaryConfiguration": {
+          "BucketNotificationConfiguration": {
+            "configurations": {
+              "notification-001": {},
+              "notification-002": {}
+            }
+          }
+        }
+      },
+      {
+        "supplementaryConfiguration": {
+          "BucketNotificationConfiguration": {
+            "configurations": {
+              "notification-001": {}
+            }
+          }
+        }
+      }
+    ],
+    "L-55BA2C6C": [
+      {
+        "tags": [
+          {}
+        ]
+      },
+      {
+        "tags": [
+          {},
+          {}
+        ]
+      }
+    ],
     "L-DC2B2D3D": [
       {
         "resourceId": "bucket-001"

--- a/service_quotas_manager/tests/test_custom_collection_queries.py
+++ b/service_quotas_manager/tests/test_custom_collection_queries.py
@@ -67,6 +67,63 @@ class TestCustomCollectionQueries:
                 {"subjectAlternativeNames": ["alt-name-1", "alt-name-2"]},
                 {"subjectAlternativeNames": ["alt-name-1"]},
             ],
+            "L-45FE3B85": [{"resourceId": "gw-001"}, {"resourceId": "gw-002"}],
+            "L-5F53652F": [
+                {
+                    "configuration": {
+                        "natGatewayAddresses": [
+                            {"associationId": "eipassoc-001"},
+                            {"associationId": "eipassoc-002"},
+                        ]
+                    }
+                },
+                {
+                    "configuration": {
+                        "natGatewayAddresses": [{"associationId": "eipassoc-001"}]
+                    }
+                },
+            ],
+            "L-1B52E74A": [{"resourceId": "ep-001"}, {"resourceId": "ep-002"}],
+            "L-29B6F2EB": [
+                {"vpcId": "vpc-001", "COUNT(*)": 1},
+                {"vpcId": "vpc-002", "COUNT(*)": 2},
+            ],
+            "L-83CA0A9D": [
+                {
+                    "configuration": {
+                        "cidrBlockAssociationSet": [
+                            {"cidrBlockState": {"state": "associated"}}
+                        ]
+                    }
+                },
+                {
+                    "configuration": {
+                        "cidrBlockAssociationSet": [
+                            {"cidrBlockState": {"state": "associated"}},
+                            {"cidrBlockState": {"state": "associated"}},
+                        ]
+                    }
+                },
+            ],
+            "L-93826ACB": [
+                {"configuration": {"routes": [{}, {}]}},
+                {"configuration": {"routes": [{}]}},
+            ],
+            "L-2AFB9258": [
+                {
+                    "relationships": [
+                        {"resourceType": "AWS::EC2::SecurityGroup"},
+                        {"resourceType": "AWS::EC2::SecurityGroup"},
+                        {"resourceType": "AWS::EC2::Subnet"},
+                    ]
+                },
+                {
+                    "relationships": [
+                        {"resourceType": "AWS::EC2::VPC"},
+                        {"resourceType": "AWS::EC2::Subnet"},
+                    ]
+                },
+            ],
         }
 
     def test_custom_collection_queries(self, expression_results):
@@ -75,6 +132,7 @@ class TestCustomCollectionQueries:
         )
         for service in all_queries:
             for quota_code, defs in all_queries[service].items():
+                print(f"Testing {defs['parameters']['jmespath']}")
                 assert (
                     float(
                         jmespath.search(

--- a/service_quotas_manager/tests/test_custom_collection_queries.py
+++ b/service_quotas_manager/tests/test_custom_collection_queries.py
@@ -1,144 +1,27 @@
 import json
 
 import jmespath
-import pytest
 
 
 class TestCustomCollectionQueries:
-    @pytest.fixture
-    def expression_results(self):
-        return {
-            "L-0263D0A3": [{"resourceId": "eip-001"}, {"resourceId": "eip-002"}],
-            "L-FB451C26": [{"resourceId": "lt-001"}, {"resourceId": "lt-002"}],
-            "L-9FEE3D26": [{"resourceId": "eni-001"}, {"resourceId": "eni-002"}],
-            "L-DC2B2D3D": [{"resourceId": "bucket-001"}, {"resourceId": "bucket-002"}],
-            "L-407747CB": [
-                {"vpcId": "vpc-001", "COUNT(*)": 1},
-                {"vpcId": "vpc-002", "COUNT(*)": 2},
-            ],
-            "L-589F43AA": [
-                {"vpcId": "vpc-001", "COUNT(*)": 1},
-                {"vpcId": "vpc-002", "COUNT(*)": 2},
-            ],
-            "L-A4707A72": [{"resourceId": "igw-001"}, {"resourceId": "igw-002"}],
-            "L-B4A6D682": [
-                {"vpcId": "vpc-001", "COUNT(*)": 1},
-                {"vpcId": "vpc-002", "COUNT(*)": 2},
-            ],
-            "L-DF5E4CA3": [{"resourceId": "eni-001"}, {"resourceId": "eni-002"}],
-            "L-E79EC296": [{"resourceId": "sg-001"}, {"resourceId": "sg-002"}],
-            "L-F678F1CE": [{"resourceId": "vpc-001"}, {"resourceId": "vpc-002"}],
-            "L-F98FE922": [{"resourceId": "tbl-001"}, {"resourceId": "tbl-002"}],
-            "L-F7858A77": [
-                {"configuration": {"globalSecondaryIndexes": ["a", "b"]}},
-                {"configuration": {"globalSecondaryIndexes": ["a"]}},
-            ],
-            "L-AA0FF27B": [
-                {"configuration": {"endpointConfiguration": {"types": ["REGIONAL"]}}},
-                {"configuration": {"endpointConfiguration": {"types": ["REGIONAL"]}}},
-            ],
-            "L-A966AB5C": [
-                {"configuration": {"endpointConfiguration": {"types": ["PRIVATE"]}}},
-                {"configuration": {"endpointConfiguration": {"types": ["PRIVATE"]}}},
-            ],
-            "L-B97207D0": [
-                {"configuration": {"endpointConfiguration": {"types": ["EDGE"]}}},
-                {"configuration": {"endpointConfiguration": {"types": ["EDGE"]}}},
-            ],
-            "L-379E48B0": [
-                {"relationships": [{"resourceType": "AWS::ApiGateway::Stage"}]},
-                {
-                    "relationships": [
-                        {"resourceType": "AWS::ApiGateway::Stage"},
-                        {"resourceType": "AWS::ApiGateway::Stage"},
-                    ]
-                },
-            ],
-            "L-01237738": [
-                {"configuration": {"layers": ["a", "b"]}},
-                {"configuration": {"layers": ["a"]}},
-            ],
-            "L-7B6409FD": [{"resourceId": "db-001"}, {"resourceId": "db-002"}],
-            "L-272F1212": [{"resourceId": "snap-001"}, {"resourceId": "snap-002"}],
-            "L-9B510759": [{"resourceId": "snap-001"}, {"resourceId": "snap-002"}],
-            "L-F141DD1D": [{"resourceId": "cert-001"}, {"resourceId": "cert-002"}],
-            "L-D2CB7DE9": [{"resourceId": "cert-001"}, {"resourceId": "cert-002"}],
-            "L-FB94F0B0": [
-                {"subjectAlternativeNames": ["alt-name-1", "alt-name-2"]},
-                {"subjectAlternativeNames": ["alt-name-1"]},
-            ],
-            "L-45FE3B85": [{"resourceId": "gw-001"}, {"resourceId": "gw-002"}],
-            "L-5F53652F": [
-                {
-                    "configuration": {
-                        "natGatewayAddresses": [
-                            {"associationId": "eipassoc-001"},
-                            {"associationId": "eipassoc-002"},
-                        ]
-                    }
-                },
-                {
-                    "configuration": {
-                        "natGatewayAddresses": [{"associationId": "eipassoc-001"}]
-                    }
-                },
-            ],
-            "L-1B52E74A": [{"resourceId": "ep-001"}, {"resourceId": "ep-002"}],
-            "L-29B6F2EB": [
-                {"vpcId": "vpc-001", "COUNT(*)": 1},
-                {"vpcId": "vpc-002", "COUNT(*)": 2},
-            ],
-            "L-83CA0A9D": [
-                {
-                    "configuration": {
-                        "cidrBlockAssociationSet": [
-                            {"cidrBlockState": {"state": "associated"}}
-                        ]
-                    }
-                },
-                {
-                    "configuration": {
-                        "cidrBlockAssociationSet": [
-                            {"cidrBlockState": {"state": "associated"}},
-                            {"cidrBlockState": {"state": "associated"}},
-                        ]
-                    }
-                },
-            ],
-            "L-93826ACB": [
-                {"configuration": {"routes": [{}, {}]}},
-                {"configuration": {"routes": [{}]}},
-            ],
-            "L-2AFB9258": [
-                {
-                    "relationships": [
-                        {"resourceType": "AWS::EC2::SecurityGroup"},
-                        {"resourceType": "AWS::EC2::SecurityGroup"},
-                        {"resourceType": "AWS::EC2::Subnet"},
-                    ]
-                },
-                {
-                    "relationships": [
-                        {"resourceType": "AWS::EC2::VPC"},
-                        {"resourceType": "AWS::EC2::Subnet"},
-                    ]
-                },
-            ],
-        }
-
-    def test_custom_collection_queries(self, expression_results):
+    def test_custom_collection_queries(self, aws_config_expression_results):
         all_queries = json.load(
             open("service_quotas_manager/custom_collection_queries.json")
         )
-        for service in all_queries:
-            for quota_code, defs in all_queries[service].items():
-                print(f"Testing {defs['parameters']['jmespath']}")
-                assert (
-                    float(
-                        jmespath.search(
-                            defs["parameters"]["jmespath"],
-                            expression_results[quota_code],
+        for service_code in all_queries:
+            for quota_code, defs in all_queries[service_code].items():
+                try:
+                    assert (
+                        float(
+                            jmespath.search(
+                                defs["parameters"]["jmespath"],
+                                aws_config_expression_results[service_code][quota_code],
+                            )
                         )
+                        == 2.0
                     )
-                    == 2.0
-                )
+                except AssertionError as ex:
+                    print(
+                        f"Failed JMESPath search of {defs['parameters']['jmespath']} for {service_code} / {quota_code}"
+                    )
+                    raise ex


### PR DESCRIPTION
Adds (additional) support for discovering AWS Config based config for various quotas for the following services:

- Redshift
- VPC
- S3