### PR TITLE
fix: Update the Lambda execution role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### What's Changed
 
-* No changes
+#### 🚀 Features
+
+* fix: Adding lambda in vpc , Adding kms in scheduler (#12)
 
 **Full Changelog**: https://github.com/schubergphilis/terraform-aws-mcaf-service-quotas-manager/compare/v0.4.0...v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Each role requires the following policies attached:
 | [aws_iam_role.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.service_quotas_manager_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_permission.trigger_service_quotas_manager_on_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_object.service_quotas_manager_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_scheduler_schedule.sqm_collect_service_quotas](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |

--- a/lambda.tf
+++ b/lambda.tf
@@ -59,3 +59,8 @@ resource "aws_iam_role_policy" "service_quotas_manager_execution_policy" {
     service_quotas_manager_bucket_arn = module.service_quotas_manager_bucket.arn
   })
 }
+
+resource "aws_iam_role_policy_attachment" "service_quotas_manager_vpc_access" {
+  role       = aws_iam_role.service_quotas_manager_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

When a lambda is deployed in VPC, the AWSLambdaVPCAccessExecutionRole needs to be attached to lambda
## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
