### PR TITLE
fix: Make the inline policy as managed policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Each role requires the following policies attached:
 | [aws_iam_policy.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.service_quotas_manager_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_execution_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Each role requires the following policies attached:
 | [aws_iam_role.service_quotas_manager_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.service_quotas_manager_execution_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_permission.trigger_service_quotas_manager_on_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ Each role requires the following policies attached:
 |------|------|
 | [aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.trigger_service_quotas_manager_on_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.service_quotas_manager_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.service_quotas_manager_execution_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_execution_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_schedules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.service_quotas_manager_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/lambda.tf
+++ b/lambda.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role" "service_quotas_manager_execution_role" {
   tags                 = var.tags
 }
 
-resource "aws_iam_role_policy" "service_quotas_manager_execution_policy" {
+resource "aws_iam_policy" "service_quotas_manager_execution_policy" {
   name = "ServiceQuotasManagerExecutionPolicy-${data.aws_region.current.name}"
 
   policy = templatefile("${path.module}/templates/lambda_execution_policy.json.tpl", {
@@ -66,5 +66,5 @@ resource "aws_iam_role_policy_attachment" "service_quotas_manager_vpc_access" {
 
 resource "aws_iam_role_policy_attachment" "service_quotas_manager_execution_policy_attach" {
   role       = aws_iam_role.service_quotas_manager_execution_role.name
-  policy_arn = aws_iam_role_policy.service_quotas_manager_execution_policy.arn
+  policy_arn = aws_iam_policy.service_quotas_manager_execution_policy.arn
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -49,7 +49,6 @@ resource "aws_iam_role" "service_quotas_manager_execution_role" {
 
 resource "aws_iam_role_policy" "service_quotas_manager_execution_policy" {
   name = "ServiceQuotasManagerExecutionPolicy-${data.aws_region.current.name}"
-  role = aws_iam_role.service_quotas_manager_execution_role.id
 
   policy = templatefile("${path.module}/templates/lambda_execution_policy.json.tpl", {
     account_id                        = data.aws_caller_identity.current.id
@@ -63,4 +62,9 @@ resource "aws_iam_role_policy" "service_quotas_manager_execution_policy" {
 resource "aws_iam_role_policy_attachment" "service_quotas_manager_vpc_access" {
   role       = aws_iam_role.service_quotas_manager_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "service_quotas_manager_execution_policy_attach" {
+  role       = aws_iam_role.service_quotas_manager_execution_role.name
+  policy_arn = aws_iam_role_policy.service_quotas_manager_execution_policy.arn
 }

--- a/tests/service-quotas-manager.tftest.hcl
+++ b/tests/service-quotas-manager.tftest.hcl
@@ -87,7 +87,7 @@ run "basic" {
   }
 
   assert {
-    condition     = length(jsondecode(aws_iam_role_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 1
+    condition     = length(jsondecode(aws_iam_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 1
     error_message = "Expected the service quota manager to only assume a role in configured target accounts."
   }
 }
@@ -144,7 +144,7 @@ run "increase_config" {
   }
 
   assert {
-    condition     = length(jsondecode(aws_iam_role_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 1
+    condition     = length(jsondecode(aws_iam_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 1
     error_message = "Expected the service quota manager to only assume a role in configured target accounts."
   }
 }
@@ -191,7 +191,7 @@ run "multi_account" {
   }
 
   assert {
-    condition     = length(jsondecode(aws_iam_role_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 2
+    condition     = length(jsondecode(aws_iam_policy.service_quotas_manager_execution_policy.policy)["Statement"][2]["Resource"]) == 2
     error_message = "Expected the service quota manager to only assume a role in configured target accounts."
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Currently the ServiceQuotasManagerExecutionPolicy assumes role in every AWS account . With the huge number of AWS accounts, and assume role every in each account, the policy size exceeds. Hence we are trying to change from inline policy to managed policy. 

## :rocket: Motivation

To fix the issue 
"LimitExceeded: Maximum policy size of 10240 bytes exceeded for role ServiceQuotasManagerExecutionRole-eu-central-1"

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
