### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,21 +166,21 @@ Each role requires the following policies attached:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.4.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service_quotas_manager_bucket"></a> [service\_quotas\_manager\_bucket](#module\_service\_quotas\_manager\_bucket) | schubergphilis/mcaf-s3/aws | ~> 0.12.1 |
-| <a name="module_service_quotas_manager_lambda"></a> [service\_quotas\_manager\_lambda](#module\_service\_quotas\_manager\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.1.2 |
+| <a name="module_service_quotas_manager_bucket"></a> [service\_quotas\_manager\_bucket](#module\_service\_quotas\_manager\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
+| <a name="module_service_quotas_manager_lambda"></a> [service\_quotas\_manager\_lambda](#module\_service\_quotas\_manager\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
 
 ## Resources
 
@@ -213,6 +213,7 @@ Each role requires the following policies attached:
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The optional name for the service quotas manager configuration bucket, overrides `bucket_prefix`. | `string` | `null` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The prefix for the service quotas manager configuration bucket. | `string` | `"service-quotas-manager"` | no |
 | <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration of the IAM role of the service quotas manager lambda | <pre>object({<br/>    name_prefix          = optional(string, "ServiceQuotasManagerExecutionRole")<br/>    path                 = optional(string, "/")<br/>    permissions_boundary = optional(string, null)<br/>  })</pre> | `{}` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where the resources will be created. If omitted, the default provider region is used. | `string` | `null` | no |
 | <a name="input_schedule_timezone"></a> [schedule\_timezone](#input\_schedule\_timezone) | The timezone to schedule service quota metric collection in | `string` | `"Europe/Amsterdam"` | no |
 | <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | n/a | <pre>list(object({<br/>    cidr_ipv4                    = optional(string)<br/>    cidr_ipv6                    = optional(string)<br/>    description                  = string<br/>    from_port                    = optional(number, 0)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number, 0)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "cidr_ipv4": "0.0.0.0/0",<br/>    "description": "Default Security Group rule for Service Quota Manager Lambda",<br/>    "ip_protocol": "tcp",<br/>    "to_port": 443<br/>  }<br/>]</pre> | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | VPC subnets where Lambda is deployed | `list(string)` | `null` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 This document captures the required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v2.0.0
+
+### Key Changes v2.0.0
+
+This module now requires a minimum AWS provider version of 6.0 to support the region parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
 ## Upgrading to v1.0.0
 
 ### Key Changes v1.0.0

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -3,6 +3,7 @@ resource "aws_cloudwatch_event_rule" "trigger_service_quotas_manager_on_alarm" {
 
   name        = "ServiceQuotaManagerIncreaserOnAlarm"
   description = "Event rule to trigger the Service Quota Manager if a quota reaches its configured threshold."
+  region      = local.account_region
   tags        = var.tags
 
   event_pattern = jsonencode({
@@ -22,8 +23,9 @@ resource "aws_cloudwatch_event_rule" "trigger_service_quotas_manager_on_alarm" {
 resource "aws_cloudwatch_event_target" "trigger_service_quotas_manager_on_alarm" {
   count = local.has_increase_config ? 1 : 0
 
-  arn  = module.service_quotas_manager_lambda.arn
-  rule = aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm[0].name
+  arn    = module.service_quotas_manager_lambda.arn
+  region = local.account_region
+  rule   = aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm[0].name
 
   input_transformer {
     input_paths = {
@@ -44,13 +46,15 @@ resource "aws_lambda_permission" "trigger_service_quotas_manager_on_alarm" {
   action         = "lambda:InvokeFunction"
   function_name  = module.service_quotas_manager_lambda.name
   principal      = "events.amazonaws.com"
-  source_account = data.aws_caller_identity.current.account_id
+  region         = local.account_region
+  source_account = local.account_id
   source_arn     = aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm[0].arn
 }
 
 resource "aws_scheduler_schedule_group" "service_quotas_manager" {
-  name = "ServiceQuotaManager"
-  tags = var.tags
+  name   = "ServiceQuotaManager"
+  region = local.account_region
+  tags   = var.tags
 }
 
 resource "aws_scheduler_schedule" "sqm_collect_service_quotas" {
@@ -62,6 +66,7 @@ resource "aws_scheduler_schedule" "sqm_collect_service_quotas" {
   kms_key_arn                  = var.kms_key_arn
   schedule_expression          = "cron(0 * ? * * *)"
   schedule_expression_timezone = var.schedule_timezone
+  region                       = local.account_region
 
   flexible_time_window {
     mode                      = "FLEXIBLE"
@@ -82,16 +87,16 @@ resource "aws_scheduler_schedule" "sqm_collect_service_quotas" {
 }
 
 resource "aws_iam_role" "service_quotas_manager_schedules" {
-  name = "ServiceQuotaManagerSchedulerRole-${data.aws_region.current.name}"
+  name = "ServiceQuotaManagerSchedulerRole-${local.account_region}"
   tags = var.tags
 
   assume_role_policy = templatefile("${path.module}/templates/service_quotas_manager_scheduler_assume_role_policy.json.tpl", {
-    account_id = data.aws_caller_identity.current.account_id
+    account_id = local.account_id
   })
 }
 
 resource "aws_iam_policy" "service_quotas_manager_schedules" {
-  name = "ServiceQuotaManagerSchedulerPolicy-${data.aws_region.current.name}"
+  name = "ServiceQuotaManagerSchedulerPolicy-${local.account_region}"
   path = "/"
   tags = var.tags
 

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_event_rule" "trigger_service_quotas_manager_on_alarm" {
 
   name        = "ServiceQuotaManagerIncreaserOnAlarm"
   description = "Event rule to trigger the Service Quota Manager if a quota reaches its configured threshold."
-  region      = local.account_region
+  region      = var.region
   tags        = var.tags
 
   event_pattern = jsonencode({
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_event_target" "trigger_service_quotas_manager_on_alarm"
   count = local.has_increase_config ? 1 : 0
 
   arn    = module.service_quotas_manager_lambda.arn
-  region = local.account_region
+  region = var.region
   rule   = aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm[0].name
 
   input_transformer {
@@ -46,14 +46,14 @@ resource "aws_lambda_permission" "trigger_service_quotas_manager_on_alarm" {
   action         = "lambda:InvokeFunction"
   function_name  = module.service_quotas_manager_lambda.name
   principal      = "events.amazonaws.com"
-  region         = local.account_region
+  region         = var.region
   source_account = local.account_id
   source_arn     = aws_cloudwatch_event_rule.trigger_service_quotas_manager_on_alarm[0].arn
 }
 
 resource "aws_scheduler_schedule_group" "service_quotas_manager" {
   name   = "ServiceQuotaManager"
-  region = local.account_region
+  region = var.region
   tags   = var.tags
 }
 
@@ -66,7 +66,7 @@ resource "aws_scheduler_schedule" "sqm_collect_service_quotas" {
   kms_key_arn                  = var.kms_key_arn
   schedule_expression          = "cron(0 * ? * * *)"
   schedule_expression_timezone = var.schedule_timezone
-  region                       = local.account_region
+  region                       = var.region
 
   flexible_time_window {
     mode                      = "FLEXIBLE"

--- a/lambda.tf
+++ b/lambda.tf
@@ -14,20 +14,19 @@ data "archive_file" "service_quotas_manager_source" {
 
 module "service_quotas_manager_lambda" {
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.1.2"
+  version = "~> 3.0.0"
 
   #checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   filename = data.archive_file.service_quotas_manager_source.output_path
 
   name                        = "ServiceQuotasManager"
-  create_policy               = false
   description                 = "Service Quotas Manager Lambda Function"
   handler                     = "service_quotas_manager.service_quotas_manager.handler"
   kms_key_arn                 = var.kms_key_arn
   log_retention               = 90
   memory_size                 = 256
+  region                      = var.region
   retries                     = 0
-  role_arn                    = aws_iam_role.service_quotas_manager_execution_role.arn
   runtime                     = "python3.11"
   security_group_egress_rules = var.security_group_egress_rules
   subnet_ids                  = var.subnet_ids
@@ -38,18 +37,22 @@ module "service_quotas_manager_lambda" {
     POWERTOOLS_SERVICE_NAME = "ServiceQuotasManager"
   }
 
+  execution_role_custom = {
+    arn = aws_iam_role.service_quotas_manager_execution_role.arn
+  }
+
   # Use a AWS provided layer to include Powertools to simplify the redistribution process.
   # Also see https://docs.powertools.aws.dev/lambda/python/latest/#lambda-layer.
   # And https://docs.aws.amazon.com/powertools/python/3.24.0/getting-started/install/#lambda-layer
   layers = [
-    "arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python311-x86_64:27"
+    "arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python311-x86_64:27"
   ]
 
   tags = var.tags
 }
 
 resource "aws_iam_role" "service_quotas_manager_execution_role" {
-  name                 = "${var.execution_role.name_prefix}-${data.aws_region.current.name}"
+  name                 = "${var.execution_role.name_prefix}-${local.account_region}"
   assume_role_policy   = file("${path.module}/templates/lambda_assume_role_policy.json")
   path                 = var.execution_role.path
   permissions_boundary = var.execution_role.permissions_boundary
@@ -57,12 +60,12 @@ resource "aws_iam_role" "service_quotas_manager_execution_role" {
 }
 
 resource "aws_iam_policy" "service_quotas_manager_execution_policy" {
-  name = "ServiceQuotasManagerExecutionPolicy-${data.aws_region.current.name}"
+  name = "ServiceQuotasManagerExecutionPolicy-${local.account_region}"
 
   policy = templatefile("${path.module}/templates/lambda_execution_policy.json.tpl", {
     account_id                        = data.aws_caller_identity.current.id
     kms_key_arn                       = var.kms_key_arn
-    region_name                       = data.aws_region.current.name
+    region_name                       = local.account_region
     role_name                         = var.assume_role.name
     role_path                         = var.assume_role.path
     service_quotas_manager_bucket_arn = module.service_quotas_manager_bucket.arn

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  account_id     = data.aws_caller_identity.current.account_id
+  account_region = var.region != null ? var.region : data.aws_region.current.region
+
   has_increase_config = sum([for item in var.quotas_manager_configuration : (item.quota_increase_config == null ? 0 : length(item.quota_increase_config))]) > 0
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -35,5 +35,5 @@ resource "aws_s3_object" "service_quotas_manager_config" {
       role_path = var.assume_role.path
     })
   ])
-  region = local.account_region
+  region = var.region
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,11 +1,12 @@
 module "service_quotas_manager_bucket" {
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 0.12.1"
+  version = "~> 2.0.0"
 
   name          = var.bucket_name
   name_prefix   = var.bucket_name == null ? var.bucket_prefix : null
   force_destroy = true
   kms_key_arn   = var.kms_key_arn
+  region        = var.region
   versioning    = true
   tags          = var.tags
 
@@ -34,4 +35,5 @@ resource "aws_s3_object" "service_quotas_manager_config" {
       role_path = var.assume_role.path
     })
   ])
+  region = local.account_region
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.25.0"
+      version = ">= 6.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "quotas_manager_configuration" {
   }
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the resources will be created. If omitted, the default provider region is used."
+}
+
 variable "schedule_timezone" {
   description = "The timezone to schedule service quota metric collection in"
   type        = string


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR updates the required AWS Provider version to v6.0 and introduces region parameter to allow defining region where the module resources will be deployed without requiring a separate provider configuration.

S3 and Lambda MCAF modules are updated to facilitate that as well.

## :rocket: Motivation

Support defining deployment region and also solves deprecation warnings for AWS Provider v6 users.

## :pencil: Additional Information

n/a
