### PR TITLE
bug: TypeError: ServiceQuota.__init__() got an unexpected keyword arg…

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -26,8 +26,8 @@ module "service_quotas_manager_bucket" {
 }
 
 resource "aws_s3_object" "service_quotas_manager_config" {
-  bucket  = module.service_quotas_manager_bucket.name
-  key     = "quotas_manager_config.json"
+  bucket = module.service_quotas_manager_bucket.name
+  key    = "quotas_manager_config.json"
   content = jsonencode([
     for cfg in var.quotas_manager_configuration : merge(cfg, {
       role_name = var.assume_role.name

--- a/s3.tf
+++ b/s3.tf
@@ -28,5 +28,10 @@ module "service_quotas_manager_bucket" {
 resource "aws_s3_object" "service_quotas_manager_config" {
   bucket  = module.service_quotas_manager_bucket.name
   key     = "quotas_manager_config.json"
-  content = jsonencode(var.quotas_manager_configuration)
+  content = jsonencode([
+    for cfg in var.quotas_manager_configuration : merge(cfg, {
+      role_name = var.assume_role.name
+      role_path = var.assume_role.path
+    })
+  ])
 }

--- a/service_quotas_manager/service_quotas_manager/entities.py
+++ b/service_quotas_manager/service_quotas_manager/entities.py
@@ -67,6 +67,7 @@ class ServiceQuota:
     quota_context: Dict = field(default_factory=lambda: {})
     usage_metric: Dict = field(default_factory=lambda: {})
     value: Optional[float] = None
+    description: str = ""
 
 
 @dataclass

--- a/service_quotas_manager/service_quotas_manager/service_quotas_manager.py
+++ b/service_quotas_manager/service_quotas_manager/service_quotas_manager.py
@@ -151,7 +151,9 @@ def handler(event: Dict, _context: LambdaContext):
         logger.error("No configuration found for account. Exiting...")
         return
 
-    assume_role_arn = f"arn:aws:iam::{account_id}:role/{config['role_name']}"
+    role_name = config.get("role_name", "ServiceQuotasManagerRole")
+    role_path = config.get("role_path", "/")
+    assume_role_arn = f"arn:aws:iam::{account_id}:role{role_path}{role_name}"
     remote_creds = _assume_role(assume_role_arn)
 
     if not remote_creds:


### PR DESCRIPTION

Summary:

TypeError: ServiceQuota.init() got an unexpected keyword argument 'description'

[ERROR] TypeError: ServiceQuota.init() got an unexpected keyword argument 'description'
Traceback (most recent call last):
File "/opt/python/aws_lambda_powertools/logging/logger.py", line 453, in decorate
return lambda_handler(event, context, args, *kwargs)
File "/var/task/service_quotas_manager/service_quotas_manager.py", line 169, in handler
sqc.collect(list(set(config.get("selected_services", []))))
File "/var/task/service_quotas_manager/service_quotas_collector.py", line 68, in collect
service_quotas = self._find_service_quotas(service["ServiceCode"])
File "/var/task/service_quotas_manager/service_quotas_collect

The Lambda function fails and cannot collect/update AWS service quotas.
Fixed this by adding description keyword in ServiceQuota class.

Another issue fixed by this:
The assume role and path is also passed to the quota manager configuration, which is updated in S3.

## :rocket: Motivation

https://github.com/schubergphilis/terraform-aws-mcaf-service-quotas-manager/issues/13

## :pencil: Additional Information
